### PR TITLE
Avoid last task override

### DIFF
--- a/contracts/NotesContract.sol
+++ b/contracts/NotesContract.sol
@@ -26,6 +26,5 @@ contract NotesContract {
     function deleteNote(uint256 _id) public {
         delete notes[_id];
         emit NoteDeleted(_id);
-        noteCount--;
     }
 }


### PR DESCRIPTION
Thanks for the example, it has been very useful for me to understand how Truffle works.

I noticed that in NoteContract.sol, the statement "noteCount--" when removing a task from listTile different from the **last task**, after doing fetchNote(), the last task is avoided because its id was not taken into account. Which causes it to no longer appear in the UI and later been replaced by another task when creating a new one.

To avoid this, it will be necessary to remove "noteCount--", in addition to the fact that there will no longer be id repetition.